### PR TITLE
Fix narrowing-conversion compile error in milesTag.h (signal_range_*_ns)

### DIFF
--- a/src/milesTag.h
+++ b/src/milesTag.h
@@ -132,8 +132,8 @@ class milesTagClass	{
 			uint8_t number_of_receivers_ = 0;										//Number of receiver channels, usually 1
 			#if defined SUPPORT_RMT_RECEIVE
 			rmt_receive_config_t global_receiver_config_ = {						//Global config across all receivers
-				.signal_range_min_ns = 2e3,											//Actually 600us but 2us is the smallest acceptable value in the SDK
-				.signal_range_max_ns = 2800e3,										//Actually 2400us but allow some margin
+				.signal_range_min_ns = 2000,											//Actually 600us but 2us is the smallest acceptable value in the SDK
+				.signal_range_max_ns = 2800000,										//Actually 2400us but allow some margin
 			};
 			//Receiver RMT data
 			rmt_symbol_word_t** received_symbols_;									//Symbol buffers


### PR DESCRIPTION
## Problem

`milesTag.h` fails to compile with the current ESP32 Arduino core
(tested with core 3.3.8 / IDF v5.5.4, Arduino IDE 2.3.8). The
`global_receiver_config_` initialiser assigns floating-point literals
to two `uint32_t` fields:

```cpp
rmt_receive_config_t global_receiver_config_ = {
    .signal_range_min_ns = 2e3,
    .signal_range_max_ns = 2800e3,
};
```

`2e3` and `2800e3` are `double` literals. Inside a braced initialiser,
a `double` -> `uint32_t` conversion is a narrowing conversion and is
ill-formed in C++. The current `xtensa-esp32-elf-g++` rejects it as an
error:

```
milesTag.h:135:56: error: narrowing conversion of '2.0e+3' from
'double' to 'uint32_t' {aka 'long unsigned int'} [-Wnarrowing]
```

Older ESP32 cores accepted it; the current toolchain does not. As it
stands, any receiver sketch fails to compile.

## Fix

Use the equivalent integer literals — same numeric values, no
narrowing conversion:

| Field                 | Before    | After      |
|-----------------------|-----------|------------|
| `signal_range_min_ns` | `2e3`     | `2000`     |
| `signal_range_max_ns` | `2800e3`  | `2800000`  |
